### PR TITLE
Preserve inline keyword in member binding.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 * Wildcard array should not be used from untyped tree. [#30](https://github.com/nojaf/telplin/issues/30)
+* Inline keyword in type extension is not preserved. [#31](https://github.com/nojaf/telplin/issues/31)
 
 ## 0.3.0 - 12-04-22
 

--- a/src/Telplin.UntypedTree/UntypedTree.fs
+++ b/src/Telplin.UntypedTree/UntypedTree.fs
@@ -54,7 +54,7 @@ let mkMember
                     bindingNode.XmlDoc,
                     bindingNode.Attributes,
                     Some valKw,
-                    None,
+                    bindingNode.Inline,
                     false,
                     None,
                     name,

--- a/tests/Telplin.Core.Tests/TypeTests.fs
+++ b/tests/Telplin.Core.Tests/TypeTests.fs
@@ -749,3 +749,21 @@ namespace Telplin
 [<Measure>]
 type LocalPath
 """
+
+[<Test>]
+let ``inline extension member, 31`` () =
+    assertSignature
+        """
+module Telplin
+
+type System.String with
+
+  member inline x.XDoc = ""
+"""
+        """
+module Telplin
+
+type System.String with
+
+    member inline XDoc: string
+"""


### PR DESCRIPTION
Fixes #31 