### PR TITLE
don't log a stacktrace on usage output

### DIFF
--- a/src/Telplin/Program.fs
+++ b/src/Telplin/Program.fs
@@ -20,7 +20,7 @@ type CliArguments =
 
 [<EntryPoint>]
 let main args =
-    let parser = ArgumentParser.Create<CliArguments> (programName = "Telplin")
+    let parser = ArgumentParser.Create<CliArguments> (programName = "Telplin", errorHandler = ProcessExiter())
     let arguments = parser.Parse (args, raiseOnUsage = false)
 
     if arguments.IsUsageRequested then

--- a/src/Telplin/Program.fs
+++ b/src/Telplin/Program.fs
@@ -20,7 +20,9 @@ type CliArguments =
 
 [<EntryPoint>]
 let main args =
-    let parser = ArgumentParser.Create<CliArguments> (programName = "Telplin", errorHandler = ProcessExiter())
+    let parser =
+        ArgumentParser.Create<CliArguments> (programName = "Telplin", errorHandler = ProcessExiter ())
+
     let arguments = parser.Parse (args, raiseOnUsage = false)
 
     if arguments.IsUsageRequested then


### PR DESCRIPTION
This is a console UX nicety - displaying usage shouldn't report a stacktrace - traces should only occur from exceptions that _you_ log in the app. Here's a comparison of the two approaches (this fix is first, then the current tool's output):

![image](https://user-images.githubusercontent.com/573979/234907958-b72acb6e-9548-45f2-baa4-bd860e32910c.png)
