### PR TITLE
Improve cli arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,26 +1,26 @@
 # Changelog
 
-## [Unreleased]
+## 0.4.0 - 28-04-23
 
 ### Fixed
 * Add support for enums.
 * Add support for type delegates.
 
 ### Added
-* Also generate an `.rsp` file from the input `.fsproj` file using `--record`
+* Also generate an `.rsp` file from the input `.fsproj` file using `--record`.
 * Only record an `.rsp` file using `--record-only`.
 
 ### Changed
-* The main input also accepts a `.rsp` file next to an `.fsproj`.
+* The main input also accepts a `.rsp` file or `.binlog` file next to an `.fsproj`.
 * Replace `--write` with `--dry-run`. The behaviour is now inverted. By default files will be written.
 
-## 0.3.2 - 28-04-22
+## 0.3.2 - 28-04-23
 
 ### Fixed
 * Override val not respected. [#38](https://github.com/nojaf/telplin/issues/38)
 * Constraint is missing from binding. [#39](https://github.com/nojaf/telplin/issues/39)
 
-## 0.3.1 - 25-04-22
+## 0.3.1 - 25-04-23
 
 ### Fixed
 * Wildcard array should not be used from untyped tree. [#30](https://github.com/nojaf/telplin/issues/30)
@@ -28,7 +28,7 @@
 * with get,set is lost. [#33](https://github.com/nojaf/telplin/issues/33)
 * Generic type argument should be preserved. [#32](https://github.com/nojaf/telplin/issues/32)
 
-## 0.3.0 - 12-04-22
+## 0.3.0 - 12-04-23
 
 ### Changed
 * The console application no longer takes an MSBuild binary log file as input, but a `fsproj`instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@
 * Add support for enums.
 * Add support for type delegates.
 
+### Added
+* Also generate an `.rsp` file from the input `.fsproj` file using `--record`
+* Only record an `.rsp` file using `--record-only`.
+
+### Changed
+* The main input also accepts a `.rsp` file next to an `.fsproj`.
+
 ## 0.3.2 - 28-04-22
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Changed
 * The main input also accepts a `.rsp` file next to an `.fsproj`.
+* Replace `--write` with `--dry-run`. The behaviour is now inverted. By default files will be written.
 
 ## 0.3.2 - 28-04-22
 

--- a/src/Telplin.Core/Library.fs
+++ b/src/Telplin.Core/Library.fs
@@ -60,5 +60,5 @@ type internal TelplinInternalApi =
 
 type TelplinApi =
     static member MkSignature (implementation : string, binlog : string) : string =
-        let options = Telplin.TypedTree.Options.mkOptions binlog
+        let options = Telplin.TypedTree.Options.mkOptionsFromBinaryLog binlog
         TelplinInternalApi.MkSignature (implementation, options)

--- a/src/Telplin.TypedTree/Options.fs
+++ b/src/Telplin.TypedTree/Options.fs
@@ -48,9 +48,7 @@ let readCompilerArgsFromBinLog file =
         let idx = args.IndexOf "-o:"
         args.Substring(idx).Split [| '\n' |]
 
-let mkOptions binLogPath =
-    let compilerArgs = readCompilerArgsFromBinLog binLogPath
-
+let mkOptions (compilerArgs : string array) =
     let sourceFiles =
         compilerArgs
         |> Array.filter (fun (line : string) -> isFSharpFile line && File.Exists line)
@@ -71,3 +69,11 @@ let mkOptions binLogPath =
         OriginalLoadReferences = []
         Stamp = None
     }
+
+let mkOptionsFromBinaryLog binLogPath =
+    let compilerArgs = readCompilerArgsFromBinLog binLogPath
+    mkOptions compilerArgs
+
+let mkOptionsFromResponseFile responseFilePath =
+    let compilerArgs = File.ReadAllLines responseFilePath
+    mkOptions compilerArgs

--- a/src/Telplin.TypedTree/Options.fs
+++ b/src/Telplin.TypedTree/Options.fs
@@ -43,7 +43,7 @@ let readCompilerArgsFromBinLog file =
     )
 
     match args with
-    | None -> failwith $"Could not parse binlog at {file}"
+    | None -> failwith $"Could not parse binlog at {file}, does it contain CoreCompile?"
     | Some args ->
         let idx = args.IndexOf "-o:"
         args.Substring(idx).Split [| '\n' |]

--- a/src/Telplin.TypedTree/Options.fsi
+++ b/src/Telplin.TypedTree/Options.fsi
@@ -2,4 +2,5 @@
 
 open FSharp.Compiler.CodeAnalysis
 
-val mkOptions : binLogPath : string -> FSharpProjectOptions
+val mkOptionsFromBinaryLog : binLogPath : string -> FSharpProjectOptions
+val mkOptionsFromResponseFile : responseFilePath : string -> FSharpProjectOptions

--- a/src/Telplin.TypedTree/Telplin.TypedTree.fsproj
+++ b/src/Telplin.TypedTree/Telplin.TypedTree.fsproj
@@ -14,7 +14,7 @@
 
     <ItemGroup>
         <PackageReference Include="FSharp.Compiler.Service" Version="$(FCSVersion)" />
-        <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.790" />
+        <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.815" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Telplin/Program.fs
+++ b/src/Telplin/Program.fs
@@ -8,7 +8,7 @@ open Telplin
 type CliArguments =
     | [<MainCommand>] Input of path : string
     | Files of path : string list
-    | Write
+    | Dry_Run
     | Record
     | Only_Record
 
@@ -18,8 +18,7 @@ type CliArguments =
             | Input _ ->
                 "FSharp project file (.fsproj) or response file (*.rsp) to process. An fsproj will be build first by Telplin."
             | Files _ -> "Process a subset of files in the current project."
-            | Write ->
-                "Write signature files to disk. By default, Telplin will only print the signatures to the console."
+            | Dry_Run -> "Don't write signature files to disk. Only print the signatures to the console."
             | Record ->
                 "Create a response file containing compiler arguments that can be used as an alternative input to the *.fsproj file, thus avoiding the need for a full project rebuild. The response file will be saved as a *.rsp file."
             | Only_Record ->
@@ -106,15 +105,15 @@ let main args =
 
         Array.iter
             (fun (fileName, signature) ->
-                if arguments.Contains <@ Write @> then
-                    let signaturePath = Path.ChangeExtension (fileName, ".fsi")
-                    File.WriteAllText (signaturePath, signature)
-                else
+                if arguments.Contains <@ Dry_Run @> then
                     let length = fileName.Length + 4
                     printfn "%s" (String.init length (fun _ -> "-"))
                     printfn $"| %s{fileName} |"
                     printfn "%s" (String.init length (fun _ -> "-"))
                     printfn "%s" signature
+                else
+                    let signaturePath = Path.ChangeExtension (fileName, ".fsi")
+                    File.WriteAllText (signaturePath, signature)
             )
             signatures
 

--- a/src/Telplin/Program.fs
+++ b/src/Telplin/Program.fs
@@ -16,7 +16,7 @@ type CliArguments =
         member this.Usage =
             match this with
             | Input _ ->
-                "FSharp project file (.fsproj) or response file (*.rsp) to process. An fsproj will be build first by Telplin."
+                "FSharp project file (.fsproj), binary log (.binlog) or response file (.rsp) to process. An fsproj will be build first by Telplin."
             | Files _ -> "Process a subset of files in the current project."
             | Dry_Run -> "Don't write signature files to disk. Only print the signatures to the console."
             | Record ->
@@ -46,7 +46,7 @@ let main args =
         exit 1
 
     let projectOptions =
-        if input.EndsWith (".fsproj") then
+        if input.EndsWith ".fsproj" then
             let binaryLog =
                 let folder = FileInfo(input).DirectoryName
                 printfn $"Building %s{input}..."
@@ -67,6 +67,8 @@ let main args =
                 File.Delete binaryLog
 
             options
+        elif input.EndsWith ".binlog" then
+            TypedTree.Options.mkOptionsFromBinaryLog input
         else
             TypedTree.Options.mkOptionsFromResponseFile input
 

--- a/src/Telplin/Program.fs
+++ b/src/Telplin/Program.fs
@@ -104,7 +104,7 @@ let main args =
             )
 
         Array.iter
-            (fun (fileName, signature) ->
+            (fun (fileName : string, signature) ->
                 if arguments.Contains <@ Dry_Run @> then
                     let length = fileName.Length + 4
                     printfn "%s" (String.init length (fun _ -> "-"))

--- a/src/Telplin/Program.fs
+++ b/src/Telplin/Program.fs
@@ -6,17 +6,24 @@ open FSharp.Compiler.Text
 open Telplin
 
 type CliArguments =
-    | [<MainCommand>] FsProj of path : string
+    | [<MainCommand>] Input of path : string
     | Files of path : string list
     | Write
+    | Record
+    | Only_Record
 
     interface IArgParserTemplate with
         member this.Usage =
             match this with
-            | FsProj _ -> "FSharp project file (.fsproj) to process. This project will be build first by Telplin."
+            | Input _ ->
+                "FSharp project file (.fsproj) or response file (*.rsp) to process. An fsproj will be build first by Telplin."
             | Files _ -> "Process a subset of files in the current project."
             | Write ->
                 "Write signature files to disk. By default, Telplin will only print the signatures to the console."
+            | Record ->
+                "Create a response file containing compiler arguments that can be used as an alternative input to the *.fsproj file, thus avoiding the need for a full project rebuild. The response file will be saved as a *.rsp file."
+            | Only_Record ->
+                "Alternative option for --record. Only create an *.rsp file without processing any of the files."
 
 [<EntryPoint>]
 let main args =
@@ -31,63 +38,84 @@ let main args =
     else
 
     let checker = FSharpChecker.Create ()
-    let fsProj = arguments.GetResult <@ FsProj @>
+    let record = arguments.Contains <@ Record @>
+    let onlyRecord = arguments.Contains <@ Only_Record @>
+    let input = arguments.GetResult <@ Input @>
 
-    if not (File.Exists fsProj) then
-        printfn $"FSharp project \"%s{fsProj}\" does not exist."
+    if not (File.Exists input) then
+        printfn $"Input \"%s{input}\" does not exist."
         exit 1
 
-    let binaryLog =
-        let folder = FileInfo(fsProj).DirectoryName
-        printfn $"Building %s{fsProj}..."
+    let projectOptions =
+        if input.EndsWith (".fsproj") then
+            let binaryLog =
+                let folder = FileInfo(input).DirectoryName
+                printfn $"Building %s{input}..."
 
-        Cli
-            .Wrap("dotnet")
-            .WithArguments($"build \"{fsProj}\" -bl:telplin.binlog --no-incremental")
-            .WithValidation(CommandResultValidation.None)
-            .ExecuteAsync()
-            .Task.Result
-        |> ignore
+                Cli
+                    .Wrap("dotnet")
+                    .WithArguments($"build \"{input}\" -bl:telplin.binlog --no-incremental")
+                    .WithValidation(CommandResultValidation.None)
+                    .ExecuteAsync()
+                    .Task.Result
+                |> ignore
 
-        Path.Combine (folder, "telplin.binlog")
+                Path.Combine (folder, "telplin.binlog")
 
-    let projectOptions = TypedTree.Options.mkOptions binaryLog
+            let options = TypedTree.Options.mkOptionsFromBinaryLog binaryLog
 
-    if File.Exists binaryLog then
-        File.Delete binaryLog
+            if File.Exists binaryLog then
+                File.Delete binaryLog
 
-    let signatures =
-        let sourceFiles =
-            match arguments.TryGetResult <@ Files @> with
-            | None -> projectOptions.SourceFiles
-            | Some files -> List.map Path.GetFullPath files |> List.toArray
+            options
+        else
+            TypedTree.Options.mkOptionsFromResponseFile input
 
-        sourceFiles
-        |> Array.filter (fun file -> file.EndsWith ".fs")
-        |> Array.map (fun sourceFile ->
-            printfn "process: %s" sourceFile
-            let code = File.ReadAllText sourceFile
-            let sourceText = SourceText.ofString code
+    if record || onlyRecord then
+        let responseFile = Path.ChangeExtension (input, ".rsp")
 
-            let resolver =
-                TypedTree.Resolver.mkResolverFor checker sourceFile sourceText projectOptions
+        let args =
+            seq {
+                yield! projectOptions.OtherOptions
+                yield! projectOptions.SourceFiles
+            }
 
-            let signature = UntypedTree.Writer.mkSignatureFile resolver code
-            sourceFile, signature
-        )
+        File.WriteAllLines (responseFile, args)
+        printfn $"Wrote compiler argument to %s{responseFile}"
 
-    Array.iter
-        (fun (fileName, signature) ->
-            if arguments.Contains <@ Write @> then
-                let signaturePath = Path.ChangeExtension (fileName, ".fsi")
-                File.WriteAllText (signaturePath, signature)
-            else
-                let length = fileName.Length + 4
-                printfn "%s" (String.init length (fun _ -> "-"))
-                printfn $"| %s{fileName} |"
-                printfn "%s" (String.init length (fun _ -> "-"))
-                printfn "%s" signature
-        )
-        signatures
+    if not onlyRecord then
+        let signatures =
+            let sourceFiles =
+                match arguments.TryGetResult <@ Files @> with
+                | None -> projectOptions.SourceFiles
+                | Some files -> List.map Path.GetFullPath files |> List.toArray
+
+            sourceFiles
+            |> Array.filter (fun file -> file.EndsWith ".fs")
+            |> Array.map (fun sourceFile ->
+                printfn "process: %s" sourceFile
+                let code = File.ReadAllText sourceFile
+                let sourceText = SourceText.ofString code
+
+                let resolver =
+                    TypedTree.Resolver.mkResolverFor checker sourceFile sourceText projectOptions
+
+                let signature = UntypedTree.Writer.mkSignatureFile resolver code
+                sourceFile, signature
+            )
+
+        Array.iter
+            (fun (fileName, signature) ->
+                if arguments.Contains <@ Write @> then
+                    let signaturePath = Path.ChangeExtension (fileName, ".fsi")
+                    File.WriteAllText (signaturePath, signature)
+                else
+                    let length = fileName.Length + 4
+                    printfn "%s" (String.init length (fun _ -> "-"))
+                    printfn $"| %s{fileName} |"
+                    printfn "%s" (String.init length (fun _ -> "-"))
+                    printfn "%s" signature
+            )
+            signatures
 
     0

--- a/tool/client/OnlineTool.fsproj
+++ b/tool/client/OnlineTool.fsproj
@@ -8,6 +8,7 @@
     <None Include="index.html" />
     <None Include="dev-server.fsx" />
     <Compile Include="WebSocket.fs" Condition="'$(Configuration)'=='Debug'" />
+    <Compile Include="UrlTools.fsi" />
     <Compile Include="UrlTools.fs" />
     <Compile Include="App.fs" />
   </ItemGroup>

--- a/tool/client/UrlTools.fs
+++ b/tool/client/UrlTools.fs
@@ -6,7 +6,7 @@ open Thoth.Json
 open Browser
 open System
 
-let private setGetParam (encodedJson : string) : unit =
+let setGetParam (encodedJson : string) : unit =
     if not (isNullOrUndefined history.pushState) then
         let ``params`` = URLSearchParams.Create ()
         ``params``.set ("data", encodedJson)
@@ -16,15 +16,15 @@ let private setGetParam (encodedJson : string) : unit =
 
         history.pushState ({| path = newUrl |}, "", newUrl)
 
-let private encodeUrl (_x : string) : string =
+let encodeUrl (_x : string) : string =
     import "compressToEncodedURIComponent" "lz-string"
 
-let private decodeUrl (_x : string) : string =
+let decodeUrl (_x : string) : string =
     import "decompressFromEncodedURIComponent" "lz-string"
 
 let updateUrlWithData json = setGetParam (encodeUrl json)
 
-let private (|DataValueFromHash|_|) hash =
+let (|DataValueFromHash|_|) hash =
     if String.IsNullOrWhiteSpace hash then None
     elif hash.StartsWith "#data=" then Some (hash.Substring 6)
     else None

--- a/tool/client/UrlTools.fsi
+++ b/tool/client/UrlTools.fsi
@@ -1,0 +1,6 @@
+module OnlineTool.UrlTools
+
+open Thoth.Json
+
+val updateUrlWithData : json : string -> unit
+val restoreModelFromUrl : decoder : Decoder<'a> -> defaultValue : 'a -> 'a


### PR DESCRIPTION
Hello @baronfel, I noticed that the usage of the CLI tool didn't really feel well during the stream.
I'm thinking to change the following:
- Also accept a response file as input. Currently, the input is a fsproj which will be rebuilt each run. If you need to do subsequentials runs you can use the rsp file instead.
- Allow to save the fsc args as a response file. Either via `--record` while you are doing the initial run, or via `--record-only` where you wouldn't process any file at all.
- Invert `--write` with `--dry-run`. So, no arguments would always write the file to disk. Adding `--dry-run` would print to console.

Thoughts?