### PR TITLE
Remove type parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
-## Unreleased
+## 0.7.0 - 05-06-23
 
 ### Changed
 * Better error handling and partial signature generation. [#72](https://github.com/nojaf/telplin/issues/72)
+* Update FCS to 43.7.400-preview.23302.5
 
 ## 0.6.0 - 01-06-23
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,7 +20,7 @@
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageProjectUrl>https://nojaf.com/telplin/</PackageProjectUrl>
         <!-- Also bump FSharp.Core down below -->
-        <FCSVersion>43.7.400-preview.23271.1</FCSVersion>
+        <FCSVersion>43.7.400-preview.23302.5</FCSVersion>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -31,7 +31,7 @@
         <OtherFlags>--test:GraphBasedChecking</OtherFlags>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="FSharp.Core" Version="7.0.400-beta.23271.1" />
+        <PackageReference Include="FSharp.Core" Version="7.0.400-beta.23302.5" />
     </ItemGroup>
     <PropertyGroup>
         <FsDocsLicenseLink>https://github.com/nojaf/telplin/blob/main/LICENSE.md</FsDocsLicenseLink>

--- a/src/Telplin.Core/TypedTree/TypedTree.fs
+++ b/src/Telplin.Core/TypedTree/TypedTree.fs
@@ -290,18 +290,6 @@ let mkResolverFor (checker : FSharpChecker) sourceFileName sourceText projectOpt
                 with ex ->
                     Error ex.Message
 
-            member resolver.GetTypeTyparNames range =
-                try
-                    let typeSymbol, _ = findTypeSymbol range
-
-                    let getName (typar : FSharpGenericParameter) =
-                        let prefix = "'"
-                        $"{prefix}{typar.FullName}"
-
-                    typeSymbol.GenericParameters |> Seq.map getName |> Seq.toList |> Ok
-                with ex ->
-                    Error ex.Message
-
             member resolver.GetPropertyWithIndex name range =
                 try
                     let valSymbol, displayContext = findSymbolForName range name

--- a/src/Telplin.Core/Types.fs
+++ b/src/Telplin.Core/Types.fs
@@ -41,7 +41,6 @@ type TypeInfoResponse =
 type TypedTreeInfoResolver =
     abstract member GetTypeInfo : range : FSharp.Compiler.Text.range -> Result<TypeInfoResponse, string>
     abstract member GetFullForBinding : bindingNameRange : FSharp.Compiler.Text.range -> Result<BindingInfo, string>
-    abstract member GetTypeTyparNames : range : FSharp.Compiler.Text.range -> Result<string list, string>
 
     abstract member GetPropertyWithIndex :
         identifier : string -> range : FSharp.Compiler.Text.range -> Result<BindingInfo, string>

--- a/src/Telplin.Core/Types.fsi
+++ b/src/Telplin.Core/Types.fsi
@@ -44,7 +44,6 @@ type TypeInfoResponse =
 type TypedTreeInfoResolver =
     abstract member GetTypeInfo : range : FSharp.Compiler.Text.range -> Result<TypeInfoResponse, string>
     abstract member GetFullForBinding : bindingNameRange : FSharp.Compiler.Text.range -> Result<BindingInfo, string>
-    abstract member GetTypeTyparNames : range : FSharp.Compiler.Text.range -> Result<string list, string>
 
     abstract member GetPropertyWithIndex :
         identifier : string -> range : FSharp.Compiler.Text.range -> Result<BindingInfo, string>

--- a/src/Telplin.Core/UntypedTree/TypeForValNode.fsi
+++ b/src/Telplin.Core/UntypedTree/TypeForValNode.fsi
@@ -17,17 +17,11 @@ type TypedTreeInfo =
 /// And it might need some additional parentheses. For example, when the return type is a function type.
 /// </summary>
 /// <param name="typedTreeInfo">Resolved type information from the typed tree.</param>
-/// <param name="typeParameterMap">A map of generic parameters found in the untyped tree with the ones found in the typed tree.</param>
 /// <param name="parameters">Parameters found in the input Oak. These will be used to enhance the parameters in the `returnType` by adding the name (if present).</param>
-val mkTypeForValNodeBasedOnTypedTree :
-    typedTreeInfo : TypedTreeInfo -> typeParameterMap : Map<string, string> -> parameters : Pattern list -> Type
+val mkTypeForValNodeBasedOnTypedTree : typedTreeInfo : TypedTreeInfo -> parameters : Pattern list -> Type
 
 val mkTypeForValNode :
-    resolver : TypedTreeInfoResolver ->
-    nameRange : range ->
-    typeParameterMap : Map<string, string> ->
-    parameters : Pattern list ->
-        Result<Type, string>
+    resolver : TypedTreeInfoResolver -> nameRange : range -> parameters : Pattern list -> Result<Type, string>
 
 /// <summary>
 /// Specialized version of `mkTypeForValNode` taking the CompiledName of a getter or setting into account.
@@ -36,12 +30,10 @@ val mkTypeForValNode :
 /// <param name="resolver"></param>
 /// <param name="name">Compiled name, e.g. get_Name or set_Name</param>
 /// <param name="nameRange"></param>
-/// <param name="typeParameterMap"></param>
 /// <param name="parameters"></param>
 val mkTypeForGetSetMemberValNode :
     resolver : TypedTreeInfoResolver ->
     name : string ->
     nameRange : range ->
-    typeParameterMap : Map<string, string> ->
     parameters : Pattern list ->
         Result<Type, string>


### PR DESCRIPTION
FYI @Martin521, the compiler now uses the correct generic parameter names in the typed tree.
So, we no longer need to translate them from the untyped tree.