### PR TITLE
Execute MSBuild binary from dotnet 8 SDK.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.9.2 - 01-12-23
+
+### Fixed
+* Allow project cracking when dotnet sdk (via global.json) is lowered than 8.
+
 ## 0.9.1 - 22-11-23
 
 ### Fixed

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -24,12 +24,14 @@
     <PropertyGroup>
         <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
         <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
-        <WarningsAsErrors>FS0025</WarningsAsErrors>
+        <WarnOn>$(WarnOn);1182</WarnOn> <!-- Unused variables,https://learn.microsoft.com/en-us/dotnet/fsharp/language-reference/compiler-options#opt-in-warnings -->
+        <WarnOn>$(WarnOn);3390</WarnOn><!-- Malformed XML doc comments -->
         <NoWarn>NU5104;FS0075</NoWarn>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <OtherFlags>$(OtherFlags) --test:GraphBasedChecking --test:ParallelOptimization --test:ParallelIlxGen --parallelreferenceresolution</OtherFlags>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="FSharp.Core" />
+        <PackageReference Include="FSharp.Core"/>
         <PackageReference Include="FSharp.Analyzers.Build">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>build</IncludeAssets>
@@ -51,8 +53,8 @@
     </PropertyGroup>
 
     <ItemGroup Condition="'$(IsPackable)' == 'true'">
-        <None Include="$(MSBuildThisFileDirectory)icon.png" Visible="false" Pack="true" PackagePath="" />
-        <None Include="$(MSBuildThisFileDirectory)README.md" Visible="false" Pack="true" PackagePath="" />
-        <PackageReference Include="Ionide.KeepAChangelog.Tasks" PrivateAssets="all" />
+        <None Include="$(MSBuildThisFileDirectory)icon.png" Visible="false" Pack="true" PackagePath=""/>
+        <None Include="$(MSBuildThisFileDirectory)README.md" Visible="false" Pack="true" PackagePath=""/>
+        <PackageReference Include="Ionide.KeepAChangelog.Tasks" PrivateAssets="all"/>
     </ItemGroup>
 </Project>

--- a/src/Telplin.Core/TypedTree/Options.fs
+++ b/src/Telplin.Core/TypedTree/Options.fs
@@ -272,6 +272,20 @@ let mkOptionsFromDesignTimeBuild (fsproj : string) (additionalArguments : string
         return currentProject
     }
 
+let mkOptionsFromDesignTimeBuildWithoutReferences
+    (fsproj : string)
+    (additionalArguments : string)
+    : Async<FSharpProjectOptions>
+    =
+    async {
+        let fsproj = FileInfo fsproj
+
+        if not fsproj.Exists then
+            invalidArg (nameof fsproj) $"\"%s{fsproj.FullName}\" does not exist."
+
+        return! mkOptionsFromDesignTimeBuildAux fsproj additionalArguments
+    }
+
 let mkOptionsFromResponseFile responseFilePath =
     let compilerArgs = File.ReadAllLines responseFilePath
     mkOptions (FileInfo responseFilePath) compilerArgs

--- a/src/Telplin.Core/TypedTree/Options.fsi
+++ b/src/Telplin.Core/TypedTree/Options.fsi
@@ -2,5 +2,22 @@
 
 open FSharp.Compiler.CodeAnalysis
 
-val mkOptionsFromDesignTimeBuild : fsproj : string -> additionalArguments : string -> Async<FSharpProjectOptions>
+/// <summary>
+/// Construct FSharpProjectOption via the `dotnet msbuild` command.
+/// This happens out-of-process and is the coolest thing ever.
+/// </summary>
+/// <param name="fsproj">Input FSharp project</param>
+/// <param name="additionalArguments">Additional MSBuild parameters append to each cli invocation.</param>
+val mkOptionsFromDesignTimeBuild :
+    fsproj : string -> additionalArguments : string -> Async<FSharpProjectOptions>
+
+/// <summary>
+/// Does the same as `mkOptionsFromDesignTimeBuild` but won't collect any F# project references.
+/// </summary>
+/// <see cref="mkOptionsFromDesignTimeBuild"/>
+/// <param name="fsproj"></param>
+/// <param name="additionalArguments"></param>
+val mkOptionsFromDesignTimeBuildWithoutReferences:
+    fsproj : string -> additionalArguments : string -> Async<FSharpProjectOptions>
+
 val mkOptionsFromResponseFile : responseFilePath : string -> FSharpProjectOptions

--- a/src/Telplin.Core/TypedTree/Options.fsi
+++ b/src/Telplin.Core/TypedTree/Options.fsi
@@ -8,8 +8,7 @@ open FSharp.Compiler.CodeAnalysis
 /// </summary>
 /// <param name="fsproj">Input FSharp project</param>
 /// <param name="additionalArguments">Additional MSBuild parameters append to each cli invocation.</param>
-val mkOptionsFromDesignTimeBuild :
-    fsproj : string -> additionalArguments : string -> Async<FSharpProjectOptions>
+val mkOptionsFromDesignTimeBuild : fsproj : string -> additionalArguments : string -> Async<FSharpProjectOptions>
 
 /// <summary>
 /// Does the same as `mkOptionsFromDesignTimeBuild` but won't collect any F# project references.
@@ -17,7 +16,7 @@ val mkOptionsFromDesignTimeBuild :
 /// <see cref="mkOptionsFromDesignTimeBuild"/>
 /// <param name="fsproj"></param>
 /// <param name="additionalArguments"></param>
-val mkOptionsFromDesignTimeBuildWithoutReferences:
+val mkOptionsFromDesignTimeBuildWithoutReferences :
     fsproj : string -> additionalArguments : string -> Async<FSharpProjectOptions>
 
 val mkOptionsFromResponseFile : responseFilePath : string -> FSharpProjectOptions

--- a/src/Telplin/Program.fs
+++ b/src/Telplin/Program.fs
@@ -70,7 +70,10 @@ let main args =
         if input.EndsWith (".fsproj", StringComparison.Ordinal) then
             let additionalArgs = String.concat " " additionalArgs
 
-            TypedTree.Options.mkOptionsFromDesignTimeBuild input additionalArgs
+            if onlyRecord then
+                TypedTree.Options.mkOptionsFromDesignTimeBuildWithoutReferences input additionalArgs
+            else
+                TypedTree.Options.mkOptionsFromDesignTimeBuild input additionalArgs
             |> Async.RunSynchronously
         else
             TypedTree.Options.mkOptionsFromResponseFile input


### PR DESCRIPTION
Hey @baronfel,

Could I get your two cents on my MSBuild-fu?
I'm trying to perform design time builds with `--getItem:` and `getProperty:` goodness.

In this PR, I'm locating the dotnet 8 `MSBuild.dll` run it directly when the user has a `global.json` locked still on `7.0.X`. 

Invoking `dotnet "C:\Program Files\dotnet\sdk\8.0.100\MSBuild.dll"` works surprisingly well.
But it might be sacrilege 🤔?
I do need to pass in `FscToolPath` and `FscToolExe` when running the design time build, and it also helps to target a specific framework. 
These are all things I can live with, but I wanted to check what your thoughts are on the matter.