### PR TITLE
Use /restore for design time build.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
-## Unreleased
+## 0.9.4 - 2024-01-29
 
 ### Fixed
 * `[<Class>]` attribute is missing when constructor is private. [#177](https://github.com/nojaf/telplin/issues/177)
+* Use /restore for design time build. [#187](https://github.com/nojaf/telplin/pull/187)
 
 ## 0.9.3 - 2023-12-12
 


### PR DESCRIPTION
Insight from Chester:

imagine with me for a moment how MSBuild works for a given project:
- it opens the project file
- it reads and loads the MSBuild SDKs specified in the project file
- it follows any Imports in those props/targets
- it then executes the targets involved

this is why the /restore flag exists - this tells MSbuild-the-engine to do an entirely separate call to /t:Restore before whatever you specified, so that the targets you specified run against a fully-correct local environment with all the props/targets files